### PR TITLE
Prepare for ember-cli-fastboot 1.0 build change

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,12 @@
 'use strict';
 
 var path = require('path');
-var dirname = path.dirname;
+
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel = require('broccoli-funnel');
+var map = require('broccoli-stew').map;
+
+var dirname = path.dirname;
 
 module.exports = {
   name: 'ember-background-video',
@@ -18,16 +21,24 @@ module.exports = {
 
     var jbv = dirname(require.resolve('jquery-background-video'));
 
-    var jbvTree = new Funnel(this.treeGenerator(jbv), {
+    var jbvJsTree = new Funnel(this.treeGenerator(jbv), {
       srcDir: '/',
       files: [
         'jquery.background-video.js',
-        'jquery.background-video.css'
       ],
       destDir: 'jquery-background-video'
     });
-
-    trees.push(jbvTree);
+    var jbvCssTree = new Funnel(this.treeGenerator(jbv), {
+      srcDir: '/',
+      files: [
+        'jquery.background-video.css',
+      ],
+      destDir: 'jquery-background-video'
+    });
+    jbvJsTree = map(jbvJsTree,
+        (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+    trees.push(jbvJsTree);
+    trees.push(jbvCssTree);
 
     return mergeTrees(trees);
   },
@@ -39,9 +50,6 @@ module.exports = {
     this.app = app;
 
     app.import('vendor/jquery-background-video/jquery.background-video.css');
-
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import('vendor/jquery-background-video/jquery.background-video.js');
-    }
+    app.import('vendor/jquery-background-video/jquery.background-video.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-stew": "^1.5.0",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "2.9.1",
+    "ember-cli": "2.14.0-beta.2",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.0.10",


### PR DESCRIPTION
Hi there, ember-cli-fastboot 1.0 will have backwards incompatible changes. Please see doc here https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c. The motivation for this change is documented here ember-fastboot/ember-cli-fastboot#387
The environment variable EMBER_CLI_FASTBOOTdoesn't exists any more in ember-cli-fastboot 1.0 build. I made the changes here, please review.